### PR TITLE
Add new HSTS entry

### DIFF
--- a/pkg/groupie/groups.go
+++ b/pkg/groupie/groups.go
@@ -120,6 +120,7 @@ var (
 		"HTTP X-Frame-Options Misconfiguration":                           "http-headers",
 		"HTTP Content Security Policy Is Malformed":                       "http-headers",
 		"HSTS Missing From HTTPS Server":                                  "http-headers",
+		"HSTS Missing From HTTPS Server (RFC 6797)":                       "http-headers",		
 
 		// SSL Configuration group
 		"Weak SSL/TLS Ciphersuites":                                                             "ssl",


### PR DESCRIPTION
Maybe the line above can be deleted, but not 100% sure, so keeping it.
The plugin in Tenable was updated 2.Dec 2020, which may have introduced the name change (couldn't find any changelog for this). See https://www.tenable.com/plugins/nessus/142960.